### PR TITLE
don't update doc with an empty object (no $set)

### DIFF
--- a/lib/client/ground.db.js
+++ b/lib/client/ground.db.js
@@ -358,7 +358,9 @@ UpdateLogic = class UpdateLogic {
   }
 
   changed(id, fields, oldDoc) {
-    this.collection._collection.update({ _id: id }, this.modifier(fields));
+    if (!_.empty(fields)) {
+      this.collection._collection.update({ _id: id }, this.modifier(fields));
+    }
   }
 
   removed(id, oldDoc) {


### PR DESCRIPTION
You were erasing existing fields (full splat) rather then updating the doc with $set.

the original object in storage before server connection
```
{
  _id: "Wg3mXjjsNCqinwdGi",
  name: "testing”
}
```
As of server connection
in conflictHandler before ddp.msg switch
```
DDP Object {
  msg: "added”, 
  collection: "groups”, 
  id: "Wg3mXjjsNCqinwdGi”, 
  fields: {
     name: “testing
  }
}
“doc" Object {name: "testing”}
```
in conflictHandler - added
`"fields" Object {}`

in UpdateLogic - changed (args)
```
_id: Wg3mXjjsNCqinwdGi 
fields: Object {} 
```

in monitorChanges - added 
```
“doc" Object {_id: "Wg3mXjjsNCqinwdGi"}
```
in browser console
```
Group.findOne()
Object {_id: "Wg3mXjjsNCqinwdGi"}
```