### PR TITLE
[1.0.0 RC] Don't use collection transform

### DIFF
--- a/lib/client/ground.db.js
+++ b/lib/client/ground.db.js
@@ -79,7 +79,7 @@ Ground.Collection = class GroundCollection extends Mongo.Collection {
 
       this._connection._stores[ this._name ].update = (ddp) => {
         var mongoId = ddp.id && MongoID.idParse(ddp.id);
-        var doc = ddp.id && this._collection.findOne(mongoId);
+        var doc = ddp.id && this._collection.findOne(mongoId, {transform: null});
 
         // remove _id from document
         if (doc) delete doc._id;
@@ -226,7 +226,7 @@ Ground.Collection = class GroundCollection extends Mongo.Collection {
 
   monitorChanges() {
     // Store documents to localforage
-    this.find().observe({
+    this.find({}, {transform: null}).observe({
       'added': doc => {
         this.setLastUpdated(this.getLastUpdated(doc));
         this.saveDocument(doc);

--- a/lib/client/ground.db.js
+++ b/lib/client/ground.db.js
@@ -358,7 +358,7 @@ UpdateLogic = class UpdateLogic {
   }
 
   changed(id, fields, oldDoc) {
-    if (!_.empty(fields)) {
+    if (!_.isEmpty(fields)) {
       this.collection._collection.update({ _id: id }, this.modifier(fields));
     }
   }


### PR DESCRIPTION
As per the [meteor docs](http://docs.meteor.com/#/full/find) pass `transform: null` at the find level to do a one time disable on collection transforms. Otherwise you may end up trying to save generated data and functions.
