### PR TITLE
Limiting removing local only with query

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ Normally Ground Collections are cleaned up for local only data when subscription
   });
 
   // Manually triggering a clean up of local only data
-  groundList.removeLocalOnly();
+  // parameter query is optional, if passed, only local items that match query will be removed 
+  groundList.removeLocalOnly(query); 
 
   // Clear local data - This will empty all local data
   groundList.clear();

--- a/groundDB.client.js
+++ b/groundDB.client.js
@@ -441,7 +441,7 @@ var _removeLocalOnly = function _removeLocalOnly(query) {
 
   _groundUtil.each(self._localOnly, function _loadDatabaseEach(isLocalOnly, id) {
     if (isLocalOnly) {
-      self._collection.remove(_.extend({}, query, { _id: id }));
+      self._collection.remove({ $and: [{ _id: id }, query] });
       delete self._localOnly[id];
     }
   });

--- a/groundDB.client.js
+++ b/groundDB.client.js
@@ -228,9 +228,10 @@ var _groundDbConstructor = function _groundDbConstructor(collection, options) {
   }
 
   // Add api for Clean up local only data
-  self.collection.removeLocalOnly = function removeLocalOnly() {
+  // If passing query we'll remove only those that pass it (and of course are only local)
+  self.collection.removeLocalOnly = function removeLocalOnly(query) {
     self.isCleanedUp = true;
-    _removeLocalOnly.call(self);
+    _removeLocalOnly.call(self, query);
   };
 
   self.collection.clear = function clear(callback) {
@@ -433,12 +434,14 @@ var _checkDocs = function _checkDocs(a) {
 
 // At some point we can do a remove all local-only data? Making sure that we
 // Only got the same data as the subscription
-var _removeLocalOnly = function _removeLocalOnly() {
+// If passing query we'll remove only those that pass it (and of course are only local)
+var _removeLocalOnly = function _removeLocalOnly(query) {
   var self = this;
+  query = query || {};
 
   _groundUtil.each(self._localOnly, function _loadDatabaseEach(isLocalOnly, id) {
     if (isLocalOnly) {
-      self._collection.remove({ _id: id });
+      self._collection.remove(_.extend({}, query, { _id: id }));
       delete self._localOnly[id];
     }
   });


### PR DESCRIPTION
In some cases we want to keep *only local items* that are not part of current subscription.
You can do this now with disabling auto cleanup (`cleanupLocalData` option) and manually calling `removeLocalOnly` with query parameter.
Example:
```js
Meteor.subscribe('chapters', 'firstCourse', function() {
  Chapters.removeLocalOnly({ course: 'firstCourse' });
});
```