### PR TITLE
fix #171 query doc before it becomes removed

### DIFF
--- a/lib/client/ground.db.js
+++ b/lib/client/ground.db.js
@@ -416,9 +416,8 @@ Ground.Collection = class GroundCollection {
   }
 
   remove(selector, ...args) {
-    const result = this._collection.remove(selector, ...args);
     this.saveDocument(this._collection.findOne(selector), true);
-    return result;
+    return this._collection.remove(selector, ...args);
   }
 
 };


### PR DESCRIPTION
This solves the bug that documents couldn't be removed.
Before the doc becomes removed we must query it, so we can pass it on to `this.saveDocument()`.