### PR TITLE
Fix remove from empty collection

### DIFF
--- a/lib/client/ground.db.js
+++ b/lib/client/ground.db.js
@@ -439,7 +439,8 @@ Ground.Collection = class GroundCollection {
   remove(selector, ...args) {
     // Order of saveDocument and remove call is not important
     // when removing a document. (why we don't need carrier for the result)
-    this.saveDocument(this._collection.findOne(selector), true);
+    const doc = this._collection.findOne(selector);
+    doc && this.saveDocument(doc, true);
     return this._collection.remove(selector, ...args);
   }
 


### PR DESCRIPTION
When removing documents from empty documents, GroundDB was trying to recover not existing document and remove it, therefor raising following error:

TypeError: Cannot read property '_id' of undefined(…) TypeError: Cannot read property '_id' of undefined